### PR TITLE
Option to compress polygon on from-function

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 
 2.0.0-b0 (2022-11-29)
 ------------------
+- CDF-Main: Option to compress polygons in `from_dict()` and `from_contours`.
+- Utils: Implement functions to compress with RDP or recursive methods.
 - CDF-Main: Implement `filter` to allow filtering of annotations by feature values (aka gating).
 - CDF-Main: Implement `from_contours`.
 - CDF-Main: Implement `to_contours`.

--- a/integration_cdf_main.py
+++ b/integration_cdf_main.py
@@ -14,6 +14,16 @@ with open(json_fp, "rb") as f:
 #%%
 cdf = CytoSmartDataFormat.from_dicts(dicts=dicts)
 
+#%%
+cdf = CytoSmartDataFormat.from_dicts(
+    dicts=dicts, compress=True, mode="rdp", epsilon=0.8
+)
+
+#%%
+cdf = CytoSmartDataFormat.from_dicts(
+    dicts=dicts, compress=True, mode="recursive", n_iter=3
+)
+
 
 #%%
 contours = [json2contours(d) for d in dicts]
@@ -47,8 +57,11 @@ print(annotations)
 # %%
 # Filter with inplace=True: CDF object is updated internally. Returns CDF object to allow chaining.
 updated_cdf = cdf.filter(
-# The return does not have to be used. This is merely to show difference between inplace.
-    feature="roundness", min_val=0.5, max_val=1.0, inplace=True
+    # The return does not have to be used. This is merely to show difference between inplace.
+    feature="roundness",
+    min_val=0.5,
+    max_val=1.0,
+    inplace=True,
 ).filter(feature="area", min_val=0, max_val=1000, inplace=True)
 print(type(updated_cdf))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Numpy>=1.18, <2
 opencv-python-headless>=4.3.0.38,<5
 numpy_indexed>=0.3.5, <0.4
 scipy>=1.4.1, <2
+rdp>=0.8

--- a/tomni/cytosmart_data_format/annotations/polygon/main.py
+++ b/tomni/cytosmart_data_format/annotations/polygon/main.py
@@ -30,7 +30,7 @@ class Polygon(Annotation):
         self._has_enough_points = len(points) >= MIN_NR_POINTS
         if not self._has_enough_points:
             warnings.warn(
-                f"Polygon has less than {MIN_NR_POINTS} points. Some features may not be available."
+                f"Polygon with id: {self._id} has less than {MIN_NR_POINTS} points. Some features may not be available."
             )
 
         # features

--- a/tomni/cytosmart_data_format/utils/__init__.py
+++ b/tomni/cytosmart_data_format/utils/__init__.py
@@ -1,1 +1,1 @@
-from .main import parse_points_to_contour
+from .main import compress_polygon_points, parse_points_to_contour

--- a/tomni/cytosmart_data_format/utils/main.py
+++ b/tomni/cytosmart_data_format/utils/main.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import numpy as np
+from rdp import rdp
 
 from ..annotations import Point
 
@@ -9,3 +10,33 @@ def parse_points_to_contour(points: List[Point]) -> np.ndarray:
     contour_points = [[[point.x, point.y]] for point in points]
     contour = np.array(contour_points, dtype=np.int32)
     return contour
+
+
+def compress_polygon_points(
+    points: List[Point], mode: str, n_iter: int = 3, epsilon=0.9
+) -> List[Point]:
+    if mode == "recursive":
+        return recursive_compression(points=points, n_iter=n_iter)
+    elif mode == "rdp":
+        return rdp_compression(points=points, epsilon=epsilon)
+    else:
+        raise ValueError(
+            "Mode not supported. Supported types are `recursive` or `rdp`."
+        )
+
+
+def recursive_compression(points: List[Point], n_iter: int) -> List[Point]:
+    assert n_iter > 0, "Nr of iterations must be positive."
+
+    for _ in range(n_iter):
+        points = points[::2]
+
+    return points
+
+
+def rdp_compression(points: List[Point], epsilon: float) -> List[Point]:
+    assert 0 <= epsilon <= 1, "Epsilon must be in [0, 1]."
+
+    point_arr = [[point.x, point.y] for point in points]
+    point_arr_compressed = rdp(point_arr, epsilon=epsilon)
+    return [Point(x, y) for (x, y) in point_arr_compressed]

--- a/tomni/cytosmart_data_format/utils/test_utils.py
+++ b/tomni/cytosmart_data_format/utils/test_utils.py
@@ -121,7 +121,7 @@ class TestUtils(TestCase):
 
     def test_parse_points_to_contour_star(self):
         expected = np.array(
-            [[[1, 3]], [[2, 3]], [[3, 5]], [[5, 3]], [[3, 1]], [[2, 2]]]
+            [[[1, 3]], [[2, 3]], [[3, 5]], [[5, 3]], [[3, 1]], [[2, 2]]], dtype=np.int32
         )
 
         actual = parse_points_to_contour(self.star_shaped_points)

--- a/tomni/cytosmart_data_format/utils/test_utils.py
+++ b/tomni/cytosmart_data_format/utils/test_utils.py
@@ -1,0 +1,121 @@
+from unittest import TestCase
+
+import numpy as np
+
+from tomni.cytosmart_data_format.annotations.point.main import Point
+from tomni.cytosmart_data_format.annotations.polygon.main import Polygon
+
+from .main import parse_points_to_contour, rdp_compression, recursive_compression
+
+
+class TestUtils(TestCase):
+    def setUp(self) -> None:
+        self.epsilon = 0.9
+        self.n_iter = 1
+        self.circular_points = [
+            Point(1, 2),
+            Point(1, 4),
+            Point(2, 5),
+            Point(4, 5),
+            Point(5, 4),
+            Point(5, 2),
+            Point(4, 1),
+            Point(3, 1),
+            Point(2, 1),
+        ]
+        self.star_shaped_points = [
+            Point(1, 3),
+            Point(2, 3),
+            Point(3, 5),
+            Point(5, 3),
+            Point(3, 1),
+            Point(2, 2),
+        ]
+        self.rectangle_points = [
+            Point(1, 5),
+            Point(3, 5),
+            Point(5, 5),
+            Point(5, 1),
+            Point(3, 1),
+            Point(1, 1),
+        ]
+        self.triangle_points = [
+            Point(1, 5),
+            Point(3, 1),
+            Point(5, 5),
+        ]
+
+    def tearDown(self):
+        pass
+
+    def test_rdp_compression_star(self):
+        expected = [
+            Point(x=1, y=3),
+            Point(x=3, y=5),
+            Point(x=5, y=3),
+            Point(x=3, y=1),
+            Point(x=2, y=2),
+        ]
+        actual = rdp_compression(self.star_shaped_points, self.epsilon)
+
+        self.assertEqual(expected, actual)
+
+    def test_rdp_compression_circular(self):
+        expected = [
+            Point(x=1, y=2),
+            Point(x=1, y=4),
+            Point(x=4, y=5),
+            Point(x=5, y=2),
+            Point(x=2, y=1),
+        ]
+        actual = rdp_compression(self.circular_points, self.epsilon)
+
+        self.assertEqual(expected, actual)
+
+    def test_rdp_compression_triangle(self):
+        expected = [Point(x=1, y=5), Point(x=3, y=1), Point(x=5, y=5)]
+
+        actual = rdp_compression(self.triangle_points, self.epsilon)
+
+        self.assertEqual(expected, actual)
+
+    def test_rdp_compression_rectangle(self):
+        expected = [Point(x=1, y=5), Point(x=5, y=5), Point(x=5, y=1), Point(x=1, y=1)]
+
+        actual = rdp_compression(self.rectangle_points, self.epsilon)
+
+        self.assertEqual(expected, actual)
+
+    def test_recursive_compression_triangle(self):
+        expected = [Point(x=1, y=5), Point(x=5, y=5)]
+
+        actual = recursive_compression(self.triangle_points, self.n_iter)
+
+        self.assertEqual(expected, actual)
+
+    def test_recursive_compression_rectangle(self):
+        expected = [Point(x=1, y=5), Point(x=5, y=5), Point(x=3, y=1)]
+
+        actual = recursive_compression(self.rectangle_points, self.n_iter)
+
+        self.assertEqual(expected, actual)
+
+    def test_recursive_compression_star(self):
+        expected = [Point(x=1, y=3), Point(x=3, y=5), Point(x=3, y=1)]
+
+        actual = recursive_compression(self.star_shaped_points, self.n_iter)
+
+        self.assertEqual(expected, actual)
+
+    def test_recursive_compression_circular(self):
+        expected = [
+            Point(x=1, y=2),
+            Point(x=2, y=5),
+            Point(x=5, y=4),
+            Point(x=4, y=1),
+            Point(x=2, y=1),
+        ]
+
+        actual = recursive_compression(self.circular_points, self.n_iter)
+
+        self.assertEqual(expected, actual)

--- a/tomni/cytosmart_data_format/utils/test_utils.py
+++ b/tomni/cytosmart_data_format/utils/test_utils.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 import numpy as np
 
 from tomni.cytosmart_data_format.annotations.point.main import Point
-from tomni.cytosmart_data_format.annotations.polygon.main import Polygon
 
 from .main import parse_points_to_contour, rdp_compression, recursive_compression
 
@@ -119,3 +118,13 @@ class TestUtils(TestCase):
         actual = recursive_compression(self.circular_points, self.n_iter)
 
         self.assertEqual(expected, actual)
+
+    def test_parse_points_to_contour_star(self):
+        expected = np.array(
+            [[[1, 3]], [[2, 3]], [[3, 5]], [[5, 3]], [[3, 1]], [[2, 2]]]
+        )
+
+        actual = parse_points_to_contour(self.star_shaped_points)
+
+        np.testing.assert_array_equal(expected, actual)
+        self.assertEqual(expected.dtype, actual.dtype)


### PR DESCRIPTION
Thank you for your contribution to the **Tomni** package.

- CDF-Main: Option to compress polygons in `from_dict()` and `from_contours`.
- Utils: Implement functions to compress with RDP or recursive methods.

Before submitting/accepting this Pull Request, please make sure:

## Contributor of code

- [ ] Version number is updated
- [ ] `HISTORY.rst` is updated
- [ ] Function is tested
- [ ] `(docstring)` is added or updated
- [ ] All needed package are in [requirements.txt](requirements.txt)

**For new function**

- [ ] Functions are named based on [Python naming conventions](https://visualgit.readthedocs.io/en/latest/pages/naming_convention.html)
- [ ] Function is added to apidocx.rst
- [ ] New feature is added to `README.md` subsection `Features`
- [ ] New function is imported in all `__init__.py` that are needed

**For bugfix**
- [ ] Unit test is added that covers the bug (if possible)
- [ ] You cursed at the person that introduced the bug

## Reviewer

- [ ] Version number is updated
- [ ] `HISTORY.rst` is updated
- [ ] Function is tested
- [ ] `(docstring)` is added or updated
- [ ] All needed package are in [requirements.txt](requirements.txt)

**For new function**

- [ ] Functions are named based on [Python naming conventions](https://visualgit.readthedocs.io/en/latest/pages/naming_convention.html)
- [ ] Function is added to apidocx.rst
- [ ] New feature is added to `README.md` subsection `Features`
- [ ] New function is imported in all `__init__.py` that are needed

**For bugfix**
- [ ] Unit test is added that covers the bug (if possible)
